### PR TITLE
Support nucleus sampling parameter but default it to 1.0.

### DIFF
--- a/chatgpt.el
+++ b/chatgpt.el
@@ -62,6 +62,11 @@
   :type 'number
   :group 'chatgpt)
 
+(defcustom chatgpt-top-p 1.0
+  "Nucleus sampling parameter."
+  :type 'number
+  :group 'chatgpt)
+
 (defcustom chatgpt-input-method 'window
   "The method receive input."
   :type '(choice (const :tag "Read from minibuffer" minibuffer)
@@ -491,6 +496,7 @@ The data is consist of ROLE and CONTENT."
                  :model chatgpt-model
                  :max-tokens chatgpt-max-tokens
                  :temperature chatgpt-temperature
+                 :top-p chatgpt-top-p
                  :user user)))
 
 (defun chatgpt-type-response ()
@@ -619,6 +625,7 @@ The data is consist of ROLE and CONTENT."
       (format "model: %s" chatgpt-model) "\n"
       (format "max_tokens: %s" chatgpt-max-tokens) "\n"
       (format "temperature: %s" chatgpt-temperature) "\n"
+      (format "top-p: %s" chatgpt-top-p)
       (format "user: %s" (chatgpt-user))))
     ;; Register event to cancel lv window!
     (add-hook 'pre-command-hook #'chatgpt--pre-command-once)))


### PR DESCRIPTION
Since there is some randomness in the sampling, the model can sometimes sample completely nonsense tokens, particularly when the temperature is higher.  A method called [nucleus sampling](https://arxiv.org/abs/1904.09751) constrains the model to only sample tokens having a cumulative mass up to `top-p`.

Here's an example:

`temperature=2 and max-tokens=100:`

```
<user>: Tell me a story.

<assistant>: A long time ago, there was a magical village situated in
the enchanted forest called Greenhaven. This little town of passionate
zoologists inspired wonder amongst the five sculpted fox installations
-- Florence, Leonard Squabs-shaft Mirfox Caligon-on Hor’dory-am
Neyfabam Possfatipy Musitight Funoy Aradilio Blossbar Busheadid Boubio
Lynnomo Epurdy-be Tangorst Dencre-che Homdo, Justbil Hiageoor Pieplex,
Lotathon Ludiphos
```
I constrained this to 100 maximum tokens because it otherwise continues on producing garbage ad-nauseam. 

`temperature=2 max-tokens=100 top-p=0.95:`

```
<user>: Tell me a story.

<assistant>: Once upon a time, there was a small town called Riverdale
nestled deep in the heart of a forest. The people of Riverdale were
simple and lived peaceful lives until one day a dark shadow descended
upon the town. It started with small things, people started
disappearing, and then the livestock began to be killed one by one.

Soon the town was living in fear, afraid of who or what was behind the
dark shadow that had descended upon them. Every day, more people
disappeared, and the towns
```