### PR TITLE
Delete the "Type respone here..." prompt when the user starts typing

### DIFF
--- a/chatgpt.el
+++ b/chatgpt.el
@@ -62,6 +62,11 @@
   :type 'number
   :group 'chatgpt)
 
+(defcustom chatgpt-top-p 1.0
+  "Nucleus sampling parameter."
+  :type 'number
+  :group 'chatgpt)
+
 (defcustom chatgpt-input-method 'window
   "The method receive input."
   :type '(choice (const :tag "Read from minibuffer" minibuffer)
@@ -491,6 +496,7 @@ The data is consist of ROLE and CONTENT."
                  :model chatgpt-model
                  :max-tokens chatgpt-max-tokens
                  :temperature chatgpt-temperature
+                 :top-p chatgpt-top-p
                  :user user)))
 
 (defun chatgpt-type-response ()
@@ -619,6 +625,7 @@ The data is consist of ROLE and CONTENT."
       (format "model: %s" chatgpt-model) "\n"
       (format "max_tokens: %s" chatgpt-max-tokens) "\n"
       (format "temperature: %s" chatgpt-temperature) "\n"
+      (format "top-p: %s" chatgpt-top-p)
       (format "user: %s" (chatgpt-user))))
     ;; Register event to cancel lv window!
     (add-hook 'pre-command-hook #'chatgpt--pre-command-once)))

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -110,8 +110,8 @@
 (defvar chatgpt-instances (ht-create)
   "List of instances, each pair is consist of (index . buffer).")
 
-(defvar-local chatgpt--user-prompt "Type response here..."
-  "Prompt shown to the user in the chat input buffer.")
+(defvar-local chatgpt--window-prompt "Type response here..."
+  "Prompt shown to the user in the chat input window buffer.")
 
 (defvar-local chatgpt-instance nil
   "Instance data for each buffer.")
@@ -513,7 +513,7 @@ The data is consist of ROLE and CONTENT."
    (t
     (cl-case chatgpt-input-method
       (`minibuffer
-       (chatgpt-send-response (read-string chatgpt--user-prompt)))
+       (chatgpt-send-response (read-string "Type response: ")))
       (`window
        (chatgpt--start-input chatgpt-instance))
       (t
@@ -545,7 +545,7 @@ The data is consist of ROLE and CONTENT."
         (chatgpt-input-mode)
         (setq chatgpt-input-instance instance)
         (erase-buffer)
-        (insert chatgpt--user-prompt)
+        (insert chatgpt--window-prompt)
         (call-interactively #'set-mark-command)
         (goto-char (point-min))))  ; waiting for deletion
     (pop-to-buffer buffer `((display-buffer-in-direction)
@@ -590,7 +590,7 @@ The data is consist of ROLE and CONTENT."
 (defun chatgpt--delete-prompt-if-present ()
   "Delete the prompt text after the user starts typing."
   (when (string= (buffer-substring-no-properties (point) (point-max))
-                 chatgpt--user-prompt)
+                 chatgpt--window-prompt)
     (delete-region (point) (point-max)))
   (remove-hook 'post-self-insert-hook #'chatgpt--delete-prompt-if-present))
 

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -110,6 +110,9 @@
 (defvar chatgpt-instances (ht-create)
   "List of instances, each pair is consist of (index . buffer).")
 
+(defvar-local chatgpt--user-prompt "Type response here..."
+  "Prompt shown to the user in the chat input buffer.")
+
 (defvar-local chatgpt-instance nil
   "Instance data for each buffer.")
 
@@ -510,7 +513,7 @@ The data is consist of ROLE and CONTENT."
    (t
     (cl-case chatgpt-input-method
       (`minibuffer
-       (chatgpt-send-response (read-string "Type response: ")))
+       (chatgpt-send-response (read-string chatgpt--user-prompt)))
       (`window
        (chatgpt--start-input chatgpt-instance))
       (t
@@ -542,7 +545,7 @@ The data is consist of ROLE and CONTENT."
         (chatgpt-input-mode)
         (setq chatgpt-input-instance instance)
         (erase-buffer)
-        (insert "Type response here...")
+        (insert chatgpt--user-prompt)
         (call-interactively #'set-mark-command)
         (goto-char (point-min))))  ; waiting for deletion
     (pop-to-buffer buffer `((display-buffer-in-direction)
@@ -584,11 +587,19 @@ The data is consist of ROLE and CONTENT."
     map)
   "Keymap for `chatgpt-mode'.")
 
+(defun chatgpt--delete-prompt-if-present ()
+  "Delete the prompt text after the user starts typing."
+  (when (string= (buffer-substring-no-properties (point) (point-max))
+                 chatgpt--user-prompt)
+    (delete-region (point) (point-max)))
+  (remove-hook 'post-self-insert-hook #'chatgpt--delete-prompt-if-present))
+
 (define-derived-mode chatgpt-input-mode fundamental-mode "ChatGPT Input"
   "Major mode for `chatgpt-input-mode'.
 
 \\<chatgpt-input-mode-map>"
   (setq-local header-line-format `((:eval (chatgpt-input-header-line))))
+  (add-hook 'post-self-insert-hook #'chatgpt--delete-prompt-if-present)
   (add-hook 'post-command-hook #'chatgpt-input--post-command nil t))
 
 ;;

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -62,7 +62,7 @@
   :type 'number
   :group 'chatgpt)
 
-(defcustom chatgpt-top-p 1.0
+(defcustom chatgpt-top-p nil
   "Nucleus sampling parameter."
   :type 'number
   :group 'chatgpt)

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -625,7 +625,7 @@ The data is consist of ROLE and CONTENT."
       (format "model: %s" chatgpt-model) "\n"
       (format "max_tokens: %s" chatgpt-max-tokens) "\n"
       (format "temperature: %s" chatgpt-temperature) "\n"
-      (format "top-p: %s" chatgpt-top-p)
+      (format "top-p: %s" chatgpt-top-p) "\n"
       (format "user: %s" (chatgpt-user))))
     ;; Register event to cancel lv window!
     (add-hook 'pre-command-hook #'chatgpt--pre-command-once)))


### PR DESCRIPTION
I added a `post-self-insert-hook` to delete the prompting text when the user starts typing.  Please let me know if there's a better way to implement this -- I only have a rather cursory knowledge of elisp.

Also fixed some oddities with the `top-p` parameter.  I should have defaulted it to `nil` instead of `1.0` (even though they're currently equivalent AFAIK), and there was no "\n" in the `chatgpt-info` for that parmaeter